### PR TITLE
Event transforming done twice in AsOf

### DIFF
--- a/event-store-client/blueprints.md
+++ b/event-store-client/blueprints.md
@@ -459,7 +459,7 @@ If you want to publish your events to an event bus or message broker, you may wa
                     if ($domainEvent->createdAt() > $asOf) {
                         break;
                     }
-                    $events[] = $this->transformer->toDomainEvent($event);
+                    $events[] = $domainEvent;
                 }
 
                 if (isset($aggregateRoot)) {


### PR DESCRIPTION
i updated the example of `AsOf` event's where transformed twice to a domain event.
this is not needed and we would lose performance over it.